### PR TITLE
Use client-side prepared statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ To enable the driver, head to your `config/databases.php` file and create a new 
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                PDO::ATTR_EMULATE_PREPARES => true,
             ]) : [],
         ],
     ]


### PR DESCRIPTION
This partially fixes `artisan migrate:fresh` reported in https://github.com/singlestore-labs/singlestore-laravel-driver/issues/3 by replicating [SingleStore's official recommendation](https://docs.singlestore.com/managed-service/en/developer-resources/connect-with-application-development-tools/connect-with-laravel.html).


More information on why this is needed [here](https://docs.singlestore.com/managed-service/en/developer-resources/connect-with-application-development-tools/using-prepared-statements.html).