### PR TITLE
Drop tables one by one

### DIFF
--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -27,4 +27,34 @@ class Builder extends MySqlBuilder
 
         return parent::createBlueprint($table, $callback);
     }
+
+    /**
+     * Drop all tables from the database.
+     *
+     * @return void
+     */
+    public function dropAllTables()
+    {
+        $tables = [];
+
+        foreach ($this->getAllTables() as $row) {
+            $row = (array) $row;
+
+            $tables[] = reset($row);
+        }
+
+        if (empty($tables)) {
+            return;
+        }
+
+        $this->disableForeignKeyConstraints();
+
+        foreach ($tables as $table) {
+            $this->connection->statement(
+                $this->grammar->compileDropAllTables([$table])
+            );
+        }
+
+        $this->enableForeignKeyConstraints();
+    }
 }

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -39,6 +39,6 @@ abstract class BaseTest extends TestCase
         // configuration possible, making for the ideal developer experience.
         $app['config']->set('database.default', 'mysql');
         $app['config']->set('database.connections.mysql.driver', 'singlestore');
-        // $app['config']->set('database.connections.mysql.options.'. PDO::ATTR_EMULATE_PREPARES, true);
+        $app['config']->set('database.connections.mysql.options.' . PDO::ATTR_EMULATE_PREPARES, true);
     }
 }

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -39,5 +39,6 @@ abstract class BaseTest extends TestCase
         // configuration possible, making for the ideal developer experience.
         $app['config']->set('database.default', 'mysql');
         $app['config']->set('database.connections.mysql.driver', 'singlestore');
+        $app['config']->set('database.connections.mysql.options.'. PDO::ATTR_EMULATE_PREPARES, true);
     }
 }

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -39,6 +39,6 @@ abstract class BaseTest extends TestCase
         // configuration possible, making for the ideal developer experience.
         $app['config']->set('database.default', 'mysql');
         $app['config']->set('database.connections.mysql.driver', 'singlestore');
-        $app['config']->set('database.connections.mysql.options.'. PDO::ATTR_EMULATE_PREPARES, true);
+        // $app['config']->set('database.connections.mysql.options.'. PDO::ATTR_EMULATE_PREPARES, true);
     }
 }

--- a/tests/Hybrid/DropAllTablesTest.php
+++ b/tests/Hybrid/DropAllTablesTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @author Aaron Francis <aarondfrancis@gmail.com|https://twitter.com/aarondfrancis>
+ */
+
+namespace SingleStore\Laravel\Tests\Hybrid;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use SingleStore\Laravel\Schema\Blueprint;
+use SingleStore\Laravel\Tests\BaseTest;
+
+class DropAllTablesTest extends BaseTest
+{
+    use HybridTestHelpers;
+
+    /** @test */
+    public function it_drops_all_tables_sequentially()
+    {
+        if (!$this->runHybridIntegrations()) {
+            return;
+        }
+
+        $this->mockDatabaseConnection = false;
+
+        Schema::dropIfExists('test_drop_1');
+        Schema::dropIfExists('test_drop_2');
+
+        $this->assertFalse(Schema::hasTable('test_drop_1'));
+        $this->assertFalse(Schema::hasTable('test_drop_2'));
+
+        Schema::create('test_drop_1', function(Blueprint $table) {
+            $table->id();
+        });
+
+        Schema::create('test_drop_2', function (Blueprint $table) {
+            $table->id();
+        });
+
+        $this->assertTrue(Schema::hasTable('test_drop_1'));
+        $this->assertTrue(Schema::hasTable('test_drop_2'));
+
+        $this->getConnection()->getSchemaBuilder()->dropAllTables();
+    }
+
+}


### PR DESCRIPTION
Dropping more than one table in a single query is not supported by SingleStore, as we can see in https://github.com/singlestore-labs/singlestore-laravel-driver/issues/3#issuecomment-1151213371.

This draft PR solves this issue, but the solution can be improved.

Instead of the one item array per table, I tried using `$this->grammar->compileDrop($table)` from MySqlGrammar, but it needs the Blueprint which I don't really know how to get.

I'm leaving this draft PR here, at least as a proof of concept.