### PR TITLE
Remove handling of foreign key constraints

### DIFF
--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -47,14 +47,10 @@ class Builder extends MySqlBuilder
             return;
         }
 
-        $this->disableForeignKeyConstraints();
-
         foreach ($tables as $table) {
             $this->connection->statement(
                 $this->grammar->compileDropAllTables([$table])
             );
         }
-
-        $this->enableForeignKeyConstraints();
     }
 }


### PR DESCRIPTION
👋  small cleanup of these 2 lines I saw when reviewing the [final changes in the MR](https://github.com/singlestore-labs/singlestore-laravel-driver/pull/8/files).

We don't need to worry about this because [SingleStore does not even support foreign keys](https://docs.singlestore.com/managed-service/en/developer-resources/unsupported-mysql-features/unsupported-feature-list.html).